### PR TITLE
Set Content-Type to application/vnd.api+json

### DIFF
--- a/app/services/api-call.service.ts
+++ b/app/services/api-call.service.ts
@@ -80,7 +80,7 @@ export class ApiCall {
     return APP_CONFIG.API_BASE_URL + url;
   }
 
-  private contentTypeHeaderBuilder(contentType: string = "application/json"): Headers {
+  private contentTypeHeaderBuilder(contentType: string = "application/vnd.api+json"): Headers {
     return new Headers({'Content-Type': contentType});
   }
 


### PR DESCRIPTION
The client should send `application/vnd.api+json` to the API, see [jsonapi.org/format](http://jsonapi.org/format/#content-negotiation-clients).

I noticed that I've completely missed to document it fixed it in: 
https://github.com/justarrived/just_match_api/commit/ef2d8c50d88c16eab621962e9552c7b2337ba59a.
