### PR TITLE
DataStore (formerly LocalStorageWrapper)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,7 +5,7 @@ import {FormsModule} from '@angular/forms';
 import {AppComponent} from './app.component';
 import {AboutComponent} from './views/about/about.component';
 import {HomeComponent} from './views/home/home.component';
-import {LocalStorageWrapper} from './services/local-storage-wrapper.service';
+import {DataStore} from './services/data-store.service';
 import {ApiCall} from './services/api-call.service';
 import {AuthManager} from './services/auth-manager.service';
 import {UserProxy} from './services/proxy/user-proxy.service';
@@ -82,7 +82,7 @@ import {AppRoutingModule} from './app.routing.module';
     MyJobsComponent
   ],
   providers: [
-    LocalStorageWrapper,
+    DataStore,
     ApiCall,
     AuthManager,
     ActsAsUser,

--- a/src/app/services/acts-as-user.service.ts
+++ b/src/app/services/acts-as-user.service.ts
@@ -21,10 +21,10 @@ export class ActsAsUser {
   }
 
   private setStorage(key, value) {
-    this.dataStore.setObject(key, value);
+    this.dataStore.set(key, value);
   }
 
   private getStorage(key) {
-    return this.dataStore.getObject(key);
+    return this.dataStore.get(key);
   }
 }

--- a/src/app/services/acts-as-user.service.ts
+++ b/src/app/services/acts-as-user.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {LocalStorageWrapper} from './local-storage-wrapper.service';
+import {DataStore} from './data-store.service';
 
 const storageActAsUserIdKey: string = 'actAsUserId';
 
@@ -7,7 +7,7 @@ const storageActAsUserIdKey: string = 'actAsUserId';
 export class ActsAsUser {
   private userId: string = null;
 
-  constructor(private localStorageWrapper: LocalStorageWrapper) {
+  constructor(private DataStore: DataStore) {
     this.userId = this.getStorage(storageActAsUserIdKey);
   }
 
@@ -21,10 +21,10 @@ export class ActsAsUser {
   }
 
   private setStorage(key, value) {
-    this.localStorageWrapper.setObject(key, value);
+    this.DataStore.setObject(key, value);
   }
 
   private getStorage(key) {
-    return this.localStorageWrapper.getObject(key);
+    return this.DataStore.getObject(key);
   }
 }

--- a/src/app/services/acts-as-user.service.ts
+++ b/src/app/services/acts-as-user.service.ts
@@ -7,7 +7,7 @@ const storageActAsUserIdKey: string = 'actAsUserId';
 export class ActsAsUser {
   private userId: string = null;
 
-  constructor(private DataStore: DataStore) {
+  constructor(private dataStore: DataStore) {
     this.userId = this.getStorage(storageActAsUserIdKey);
   }
 
@@ -21,10 +21,10 @@ export class ActsAsUser {
   }
 
   private setStorage(key, value) {
-    this.DataStore.setObject(key, value);
+    this.dataStore.setObject(key, value);
   }
 
   private getStorage(key) {
-    return this.DataStore.getObject(key);
+    return this.dataStore.getObject(key);
   }
 }

--- a/src/app/services/api-call.service.ts
+++ b/src/app/services/api-call.service.ts
@@ -21,7 +21,7 @@ export class ApiCall {
   private actAsUserHeaderName: string = 'X-API-ACT-AS-USER';
 
   constructor(private http: Http,
-              private DataStore: DataStore,
+              private dataStore: DataStore,
               private router: Router,
               private userManager: UserManager,
               private actsAsUser: ActsAsUser,
@@ -64,7 +64,7 @@ export class ApiCall {
     let options = new RequestOptions(requestArgs);
 
     let req: Request = new Request(options);
-    let authorizationData = this.DataStore.getObject(this.storageAuthorizationData);
+    let authorizationData = this.dataStore.getObject(this.storageAuthorizationData);
     if (!!authorizationData) {
       req.headers.set(this.authorizationHeaderName, this.authorizationHeaderPrefix + authorizationData['auth_token']);
     }

--- a/src/app/services/api-call.service.ts
+++ b/src/app/services/api-call.service.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 import {Http, Headers, Request, RequestOptions, RequestOptionsArgs, RequestMethod, URLSearchParams} from '@angular/http';
-import {LocalStorageWrapper} from './local-storage-wrapper.service';
+import {DataStore} from './data-store.service';
 import * as  _ from 'lodash';
 import {parseJsonapiResponse, parseJsonapiErrorResponse} from '../utils/jsonapi-parser.util';
 import {Observable} from 'rxjs';
@@ -21,7 +21,7 @@ export class ApiCall {
   private actAsUserHeaderName: string = 'X-API-ACT-AS-USER';
 
   constructor(private http: Http,
-              private localStorageWrapper: LocalStorageWrapper,
+              private DataStore: DataStore,
               private router: Router,
               private userManager: UserManager,
               private actsAsUser: ActsAsUser,
@@ -64,7 +64,7 @@ export class ApiCall {
     let options = new RequestOptions(requestArgs);
 
     let req: Request = new Request(options);
-    let authorizationData = this.localStorageWrapper.getObject(this.storageAuthorizationData);
+    let authorizationData = this.DataStore.getObject(this.storageAuthorizationData);
     if (!!authorizationData) {
       req.headers.set(this.authorizationHeaderName, this.authorizationHeaderPrefix + authorizationData['auth_token']);
     }

--- a/src/app/services/api-call.service.ts
+++ b/src/app/services/api-call.service.ts
@@ -64,7 +64,7 @@ export class ApiCall {
     let options = new RequestOptions(requestArgs);
 
     let req: Request = new Request(options);
-    let authorizationData = this.dataStore.getObject(this.storageAuthorizationData);
+    let authorizationData = this.dataStore.get(this.storageAuthorizationData);
     if (!!authorizationData) {
       req.headers.set(this.authorizationHeaderName, this.authorizationHeaderPrefix + authorizationData['auth_token']);
     }

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -2,6 +2,7 @@ import {Injectable} from '@angular/core';
 import {storageTypeAvailable} from '../utils/storage-type-available';
 
 interface StorageInterface {
+  clear(): void;
   getItem(key: string): string;
   setItem(key: string, value: string): void;
   removeItem(key: string): string;
@@ -11,7 +12,6 @@ interface StorageInterface {
 
 class CookieStorage implements StorageInterface {
   private data: Object = {};
-  private length: number = 0;
   private DOM: any;
 
   constructor(document: any) {
@@ -23,7 +23,6 @@ class CookieStorage implements StorageInterface {
 
   public clear(): void {
     this.data = {};
-    this.length = 0;
     this.clearData();
   }
 
@@ -35,7 +34,6 @@ class CookieStorage implements StorageInterface {
     const oldValue = this.data[key];
     delete this.data[key];
 
-    this.length--;
     this.setData(this.data);
 
     return oldValue;
@@ -43,7 +41,6 @@ class CookieStorage implements StorageInterface {
 
   public setItem(key: string, value: string): void {
     this.data[key] = value;
-    this.length++;
     this.setData(this.data);
   }
 
@@ -106,6 +103,10 @@ class CookieStorage implements StorageInterface {
 class MemoryStorage implements StorageInterface {
   private items: Object = {};
 
+  public clear(): void {
+    this.items = {};
+  }
+
   public setItem(key: string, value: string): void {
     this.items[key] = value;
   }
@@ -131,10 +132,14 @@ class MemoryStorage implements StorageInterface {
 }
 
 class SessionStorage implements StorageInterface {
-  private store: any = {};
+  private store: any;
 
   constructor(sessionStore: any) {
     this.store = sessionStore;
+  }
+
+  public clear(): void {
+    this.store.clear();
   }
 
   public getItem(key: string) {
@@ -162,10 +167,14 @@ class SessionStorage implements StorageInterface {
 }
 
 class LocalStorage implements StorageInterface {
-  private store: any = {};
+  private store: any;
 
   constructor(store: any) {
     this.store = store;
+  }
+
+  public clear(): void {
+    this.store.clear();
   }
 
   public setItem(key: string, value: string): void {
@@ -205,6 +214,10 @@ export class DataStore {
       this.store = new CookieStorage(document);
       // this.store = new MemoryStorage();
     }
+  }
+
+  public clear(): void {
+    this.store.clear();
   }
 
   public setObject(key: string, value: any): void {

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -43,8 +43,8 @@ export class DataStore {
     return this.store.persistsSession();
   }
 
-  isCachable(): boolean {
-    return this.store.isCachable();
+  supportsCaching(): boolean {
+    return this.store.supportsCaching();
   }
 
   private set(key: string, value: string): void {

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -4,7 +4,9 @@ import {storageTypeAvailable} from '../utils/storage-type-available';
 interface StorageInterface {
   getItem(key: string): string;
   setItem(key: string, value: string): void;
-  removeItem(key: string): void;
+  removeItem(key: string): string;
+  persistsRefresh(): boolean;
+  persistsSession(): boolean;
 }
 
 class MemoryStorage implements StorageInterface {
@@ -18,8 +20,50 @@ class MemoryStorage implements StorageInterface {
     return this.items[key];
   }
 
-  public removeItem(key: string): void {
+  public removeItem(key: string): string {
+    const oldValue = this.getItem(key);
     this.setItem(key, null);
+
+    return oldValue;
+  }
+
+  public persistsRefresh(): boolean {
+    return false;
+  }
+
+  public persistsSession(): boolean {
+    return false;
+  }
+}
+
+class SessionStorage implements StorageInterface {
+  private store: any = {};
+
+  constructor(sessionStore: any) {
+    this.store = sessionStore;
+  }
+
+  public getItem(key: string) {
+    return this.store.getItem(key);
+  }
+
+  public setItem(key: string, value: string) {
+    this.store.setItem(key, value);
+  }
+
+  public removeItem(key: string): string {
+    const oldValue = this.getItem(key);
+    sessionStorage.removeItem(key);
+
+    return oldValue;
+  }
+
+  public persistsRefresh(): boolean {
+    return true;
+  }
+
+  public persistsSession(): boolean {
+    return false;
   }
 }
 
@@ -38,31 +82,34 @@ class LocalStorage implements StorageInterface {
     return this.store.getItem(key);
   }
 
-  public removeItem(key: string): void {
+  public removeItem(key: string): string {
+    const oldValue = this.getItem(key);
     this.store.removeItem(key);
+
+    return oldValue;
+  }
+
+  public persistsRefresh(): boolean {
+    return true;
+  }
+
+  public persistsSession(): boolean {
+    return true;
   }
 }
 
 @Injectable()
 export class DataStore {
-
-  public store: any;
+  private store: any;
 
   constructor() {
     if (storageTypeAvailable('localStorage')) {
       this.store = new LocalStorage(localStorage);
+    } else if (storageTypeAvailable('sessionStorage')) {
+      this.store = new SessionStorage(sessionStorage);
     } else {
       this.store = new MemoryStorage();
-      console.log('Current browser does not support Local Storage');
     }
-  }
-
-  public set(key: string, value: string): void {
-    this.store.setItem(key, value);
-  }
-
-  public get(key: string): string {
-    return this.store.getItem(key);
   }
 
   public setObject(key: string, value: any): void {
@@ -74,8 +121,33 @@ export class DataStore {
     return value ? JSON.parse(value) : null;
   }
 
-  public remove(key: string): void {
-    this.store.removeItem(key);
+  public removeObject(key: string): any {
+    const oldValue = this.getObject(key);
+    this.remove(key);
+
+    return oldValue;
   }
 
+  public persistsRefresh(): boolean {
+    return this.store.persistsRefresh();
+  }
+
+  public persistsSession(): boolean {
+    return this.store.persistsSession();
+  }
+
+  private set(key: string, value: string): void {
+    this.store.setItem(key, value);
+  }
+
+  private get(key: string): string {
+    return this.store.getItem(key);
+  }
+
+  private remove(key: string): string {
+    const oldValue = this.store.get(key);
+    this.store.removeItem(key);
+
+    return oldValue;
+  }
 }

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -21,16 +21,16 @@ class CookieStorage implements StorageInterface {
     this.data = this.getData();
   }
 
-  public clear(): void {
+  clear(): void {
     this.data = {};
     this.clearData();
   }
 
-  public getItem(key: string): string {
+  getItem(key: string): string {
     return this.data[key] === undefined ? null : this.data[key];
   }
 
-  public removeItem(key: string): string {
+  removeItem(key: string): string {
     const oldValue = this.data[key];
     delete this.data[key];
 
@@ -39,16 +39,16 @@ class CookieStorage implements StorageInterface {
     return oldValue;
   }
 
-  public setItem(key: string, value: string): void {
+  setItem(key: string, value: string): void {
     this.data[key] = value;
     this.setData(this.data);
   }
 
-  public persistsRefresh(): boolean {
+  persistsRefresh(): boolean {
     return true;
   }
 
-  public persistsSession(): boolean {
+  persistsSession(): boolean {
     return true;
   }
 
@@ -103,30 +103,30 @@ class CookieStorage implements StorageInterface {
 class MemoryStorage implements StorageInterface {
   private items: Object = {};
 
-  public clear(): void {
+  clear(): void {
     this.items = {};
   }
 
-  public setItem(key: string, value: string): void {
+  setItem(key: string, value: string): void {
     this.items[key] = value;
   }
 
-  public getItem(key: string): string {
+  getItem(key: string): string {
     return this.items[key];
   }
 
-  public removeItem(key: string): string {
+  removeItem(key: string): string {
     const oldValue = this.getItem(key);
     this.setItem(key, null);
 
     return oldValue;
   }
 
-  public persistsRefresh(): boolean {
+  persistsRefresh(): boolean {
     return false;
   }
 
-  public persistsSession(): boolean {
+  persistsSession(): boolean {
     return false;
   }
 }
@@ -138,30 +138,30 @@ class SessionStorage implements StorageInterface {
     this.store = sessionStore;
   }
 
-  public clear(): void {
+  clear(): void {
     this.store.clear();
   }
 
-  public getItem(key: string) {
+  getItem(key: string) {
     return this.store.getItem(key);
   }
 
-  public setItem(key: string, value: string) {
+  setItem(key: string, value: string) {
     this.store.setItem(key, value);
   }
 
-  public removeItem(key: string): string {
+  removeItem(key: string): string {
     const oldValue = this.getItem(key);
     sessionStorage.removeItem(key);
 
     return oldValue;
   }
 
-  public persistsRefresh(): boolean {
+  persistsRefresh(): boolean {
     return true;
   }
 
-  public persistsSession(): boolean {
+  persistsSession(): boolean {
     return false;
   }
 }
@@ -173,30 +173,30 @@ class LocalStorage implements StorageInterface {
     this.store = store;
   }
 
-  public clear(): void {
+  clear(): void {
     this.store.clear();
   }
 
-  public setItem(key: string, value: string): void {
+  setItem(key: string, value: string): void {
     this.store.setItem(key, value);
   }
 
-  public getItem(key: string): string {
+  getItem(key: string): string {
     return this.store.getItem(key);
   }
 
-  public removeItem(key: string): string {
+  removeItem(key: string): string {
     const oldValue = this.getItem(key);
     this.store.removeItem(key);
 
     return oldValue;
   }
 
-  public persistsRefresh(): boolean {
+  persistsRefresh(): boolean {
     return true;
   }
 
-  public persistsSession(): boolean {
+  persistsSession(): boolean {
     return true;
   }
 }
@@ -209,31 +209,31 @@ export class DataStore {
     this.store = this.storeFactory();
   }
 
-  public clear(): void {
+  clear(): void {
     this.store.clear();
   }
 
-  public setObject(key: string, value: any): void {
+  setObject(key: string, value: any): void {
     this.set(key, JSON.stringify(value));
   }
 
-  public getObject(key: string): any {
+  getObject(key: string): any {
     const value = this.get(key);
     return value ? JSON.parse(value) : null;
   }
 
-  public removeObject(key: string): any {
+  removeObject(key: string): any {
     const oldValue = this.getObject(key);
     this.remove(key);
 
     return oldValue;
   }
 
-  public persistsRefresh(): boolean {
+  persistsRefresh(): boolean {
     return this.store.persistsRefresh();
   }
 
-  public persistsSession(): boolean {
+  persistsSession(): boolean {
     return this.store.persistsSession();
   }
 

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -206,14 +206,7 @@ export class DataStore {
   private store: any;
 
   constructor() {
-    if (storageTypeAvailable('localStorage')) {
-      this.store = new LocalStorage(localStorage);
-    } else if (storageTypeAvailable('sessionStorage')) {
-      this.store = new SessionStorage(sessionStorage);
-    } else {
-      this.store = new CookieStorage(document);
-      // this.store = new MemoryStorage();
-    }
+    this.store = this.storeFactory();
   }
 
   public clear(): void {
@@ -257,5 +250,17 @@ export class DataStore {
     this.store.removeItem(key);
 
     return oldValue;
+  }
+
+  private storeFactory(): StorageInterface {
+    if (storageTypeAvailable('localStorage')) {
+      return new LocalStorage(localStorage);
+    } else if (storageTypeAvailable('sessionStorage')) {
+      return new SessionStorage(sessionStorage);
+    } else if (document) {
+      return new CookieStorage(document);
+    } else {
+      return new MemoryStorage();
+    }
   }
 }

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -57,7 +57,7 @@ class CookieStorage implements StorageInterface {
 
     if (days) {
       const date = new Date();
-      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      date.setTime(date.getTime() + this.daysToMillis(days));
       expires = '; expires=' + date.toUTCString();
     } else {
       expires = '';
@@ -97,6 +97,10 @@ class CookieStorage implements StorageInterface {
   private getData(): Object {
     const data = this.readCookie('localStorage');
     return data ? JSON.parse(data) : {};
+  }
+
+  private daysToMillis(days: number): number {
+    return days * 24 * 60 * 60 * 1000;
   }
 }
 

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -19,18 +19,18 @@ export class DataStore {
     this.store.clear();
   }
 
-  setObject(key: string, value: any): void {
-    this.set(key, JSON.stringify(value));
+  set(key: string, value: any): void {
+    this.setItem(key, JSON.stringify(value));
   }
 
-  getObject(key: string): any {
-    const value = this.get(key);
+  get(key: string): any {
+    const value = this.getItem(key);
     return value ? JSON.parse(value) : null;
   }
 
-  removeObject(key: string): any {
-    const oldValue = this.getObject(key);
-    this.remove(key);
+  remove(key: string): any {
+    const oldValue = this.get(key);
+    this.removeItem(key);
 
     return oldValue;
   }
@@ -47,15 +47,15 @@ export class DataStore {
     return this.store.supportsCaching();
   }
 
-  private set(key: string, value: string): void {
+  private setItem(key: string, value: string): void {
     this.store.setItem(key, value);
   }
 
-  private get(key: string): string {
+  private getItem(key: string): string {
     return this.store.getItem(key);
   }
 
-  private remove(key: string): string {
+  private removeItem(key: string): string {
     return this.store.removeItem(key);
   }
 

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -44,7 +44,7 @@ class LocalStorage implements StorageInterface {
 }
 
 @Injectable()
-export class LocalStorageWrapper {
+export class DataStore {
 
   public store: any;
 

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -1,209 +1,11 @@
 import {Injectable} from '@angular/core';
 import {storageTypeAvailable} from '../utils/storage-type-available';
 
-interface StorageInterface {
-  clear(): void;
-  getItem(key: string): string;
-  setItem(key: string, value: string): void;
-  removeItem(key: string): string;
-  persistsRefresh(): boolean;
-  persistsSession(): boolean;
-}
-
-class CookieStorage implements StorageInterface {
-  private data: Object = {};
-  private DOM: any;
-
-  constructor(document: any) {
-    this.DOM = document;
-
-    // initialise if there's already data
-    this.data = this.getData();
-  }
-
-  clear(): void {
-    this.data = {};
-    this.clearData();
-  }
-
-  getItem(key: string): string {
-    return this.data[key] === undefined ? null : this.data[key];
-  }
-
-  removeItem(key: string): string {
-    const oldValue = this.data[key];
-    delete this.data[key];
-
-    this.setData(this.data);
-
-    return oldValue;
-  }
-
-  setItem(key: string, value: string): void {
-    this.data[key] = value;
-    this.setData(this.data);
-  }
-
-  persistsRefresh(): boolean {
-    return true;
-  }
-
-  persistsSession(): boolean {
-    return true;
-  }
-
-  private createCookie(name: string, value: string, days: number): void {
-    let expires;
-
-    if (days) {
-      const date = new Date();
-      date.setTime(date.getTime() + this.daysToMillis(days));
-      expires = '; expires=' + date.toUTCString();
-    } else {
-      expires = '';
-    }
-
-    this.DOM.cookie = name + '=' + value + expires + '; path=/';
-  }
-
-  private readCookie(name: string) {
-    const nameEQ: string = name + '=';
-    const cookieParts: Array<string> = this.DOM.cookie.split(';');
-    let data: string = null;
-
-    cookieParts.forEach((c: string) => {
-      while (c.charAt(0) == ' ') {
-        c = c.substring(1, c.length);
-      }
-
-      if (c.indexOf(nameEQ) == 0) {
-        data = c.substring(nameEQ.length, c.length);
-        return;
-      }
-    });
-
-    return data;
-  }
-
-  private setData(data: any) {
-    data = JSON.stringify(data);
-    this.createCookie('localStorage', data, 365);
-  }
-
-  private clearData(): void {
-    this.createCookie('localStorage', '', 365);
-  }
-
-  private getData(): Object {
-    const data = this.readCookie('localStorage');
-    return data ? JSON.parse(data) : {};
-  }
-
-  private daysToMillis(days: number): number {
-    return days * 24 * 60 * 60 * 1000;
-  }
-}
-
-class MemoryStorage implements StorageInterface {
-  private items: Object = {};
-
-  clear(): void {
-    this.items = {};
-  }
-
-  setItem(key: string, value: string): void {
-    this.items[key] = value;
-  }
-
-  getItem(key: string): string {
-    return this.items[key];
-  }
-
-  removeItem(key: string): string {
-    const oldValue = this.getItem(key);
-    this.setItem(key, null);
-
-    return oldValue;
-  }
-
-  persistsRefresh(): boolean {
-    return false;
-  }
-
-  persistsSession(): boolean {
-    return false;
-  }
-}
-
-class SessionStorage implements StorageInterface {
-  private store: any;
-
-  constructor(sessionStore: any) {
-    this.store = sessionStore;
-  }
-
-  clear(): void {
-    this.store.clear();
-  }
-
-  getItem(key: string) {
-    return this.store.getItem(key);
-  }
-
-  setItem(key: string, value: string) {
-    this.store.setItem(key, value);
-  }
-
-  removeItem(key: string): string {
-    const oldValue = this.getItem(key);
-    sessionStorage.removeItem(key);
-
-    return oldValue;
-  }
-
-  persistsRefresh(): boolean {
-    return true;
-  }
-
-  persistsSession(): boolean {
-    return false;
-  }
-}
-
-class LocalStorage implements StorageInterface {
-  private store: any;
-
-  constructor(store: any) {
-    this.store = store;
-  }
-
-  clear(): void {
-    this.store.clear();
-  }
-
-  setItem(key: string, value: string): void {
-    this.store.setItem(key, value);
-  }
-
-  getItem(key: string): string {
-    return this.store.getItem(key);
-  }
-
-  removeItem(key: string): string {
-    const oldValue = this.getItem(key);
-    this.store.removeItem(key);
-
-    return oldValue;
-  }
-
-  persistsRefresh(): boolean {
-    return true;
-  }
-
-  persistsSession(): boolean {
-    return true;
-  }
-}
+import {StorageInterface} from '../utils/storage/storage-interface';
+import {CookieStorage} from '../utils/storage/cookie-storage';
+import {LocalStorage} from '../utils/storage/local-storage';
+import {MemoryStorage} from '../utils/storage/memory-storage';
+import {SessionStorage} from '../utils/storage/session-storage';
 
 @Injectable()
 export class DataStore {
@@ -239,6 +41,10 @@ export class DataStore {
 
   persistsSession(): boolean {
     return this.store.persistsSession();
+  }
+
+  isCachable(): boolean {
+    return this.store.isCachable();
   }
 
   private set(key: string, value: string): void {

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -9,6 +9,100 @@ interface StorageInterface {
   persistsSession(): boolean;
 }
 
+class CookieStorage implements StorageInterface {
+  private data: Object = {};
+  private length: number = 0;
+  private DOM: any;
+
+  constructor(document: any) {
+    this.DOM = document;
+
+    // initialise if there's already data
+    this.data = this.getData();
+  }
+
+  public clear(): void {
+    this.data = {};
+    this.length = 0;
+    this.clearData();
+  }
+
+  public getItem(key: string): string {
+    return this.data[key] === undefined ? null : this.data[key];
+  }
+
+  public removeItem(key: string): string {
+    const oldValue = this.data[key];
+    delete this.data[key];
+
+    this.length--;
+    this.setData(this.data);
+
+    return oldValue;
+  }
+
+  public setItem(key: string, value: string): void {
+    this.data[key] = value;
+    this.length++;
+    this.setData(this.data);
+  }
+
+  public persistsRefresh(): boolean {
+    return true;
+  }
+
+  public persistsSession(): boolean {
+    return true;
+  }
+
+  private createCookie(name: string, value: string, days: number): void {
+    let expires;
+
+    if (days) {
+      const date = new Date();
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      expires = '; expires=' + date.toUTCString();
+    } else {
+      expires = '';
+    }
+
+    this.DOM.cookie = name + '=' + value + expires + '; path=/';
+  }
+
+  private readCookie(name: string) {
+    const nameEQ: string = name + '=';
+    const cookieParts: Array<string> = this.DOM.cookie.split(';');
+    let data: string = null;
+
+    cookieParts.forEach((c: string) => {
+      while (c.charAt(0) == ' ') {
+        c = c.substring(1, c.length);
+      }
+
+      if (c.indexOf(nameEQ) == 0) {
+        data = c.substring(nameEQ.length, c.length);
+        return;
+      }
+    });
+
+    return data;
+  }
+
+  private setData(data: any) {
+    data = JSON.stringify(data);
+    this.createCookie('localStorage', data, 365);
+  }
+
+  private clearData(): void {
+    this.createCookie('localStorage', '', 365);
+  }
+
+  private getData(): Object {
+    const data = this.readCookie('localStorage');
+    return data ? JSON.parse(data) : {};
+  }
+}
+
 class MemoryStorage implements StorageInterface {
   private items: Object = {};
 
@@ -108,7 +202,8 @@ export class DataStore {
     } else if (storageTypeAvailable('sessionStorage')) {
       this.store = new SessionStorage(sessionStorage);
     } else {
-      this.store = new MemoryStorage();
+      this.store = new CookieStorage(document);
+      // this.store = new MemoryStorage();
     }
   }
 

--- a/src/app/services/data-store.service.ts
+++ b/src/app/services/data-store.service.ts
@@ -9,7 +9,7 @@ import {SessionStorage} from '../utils/storage/session-storage';
 
 @Injectable()
 export class DataStore {
-  private store: any;
+  private store: StorageInterface;
 
   constructor() {
     this.store = this.storeFactory();
@@ -56,10 +56,7 @@ export class DataStore {
   }
 
   private remove(key: string): string {
-    const oldValue = this.store.get(key);
-    this.store.removeItem(key);
-
-    return oldValue;
+    return this.store.removeItem(key);
   }
 
   private storeFactory(): StorageInterface {

--- a/src/app/services/local-storage-wrapper.service.ts
+++ b/src/app/services/local-storage-wrapper.service.ts
@@ -53,7 +53,7 @@ export class LocalStorageWrapper {
       this.store = new LocalStorage(localStorage);
     } else {
       this.store = new MemoryStorage();
-      console.error('Current browser does not support Local Storage');
+      console.log('Current browser does not support Local Storage');
     }
   }
 

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -9,8 +9,8 @@ export class TranslationService {
   private selectedLanguage: Language;
   private languageChange: EventEmitter<any> = new EventEmitter();
 
-  constructor(private translateService: TranslateService, private DataStore: DataStore) {
-    this.selectedLanguage = this.DataStore.getObject(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
+  constructor(private translateService: TranslateService, private dataStore: DataStore) {
+    this.selectedLanguage = this.dataStore.getObject(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
 
     this.translateService.addLangs(['ar', 'en', 'fa', 'fa_AF', 'ku', 'ps', 'sv', 'ti']);
     this.translateService.setDefaultLang('en');
@@ -21,7 +21,7 @@ export class TranslationService {
 
   public setLanguage(language: Language) {
     this.selectedLanguage = language;
-    this.DataStore.setObject(this.storageSelectedLanguageKey, language);
+    this.dataStore.setObject(this.storageSelectedLanguageKey, language);
     this.translateService.use(language.languageCode);
     this.languageChange.emit();
   }

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -1,6 +1,6 @@
 import {Injectable, EventEmitter} from '@angular/core';
 import {TranslateService} from 'ng2-translate/ng2-translate';
-import {LocalStorageWrapper} from './local-storage-wrapper.service';
+import {DataStore} from './data-store.service';
 import {Language} from '../models/language/language';
 
 @Injectable()
@@ -9,8 +9,8 @@ export class TranslationService {
   private selectedLanguage: Language;
   private languageChange: EventEmitter<any> = new EventEmitter();
 
-  constructor(private translateService: TranslateService, private localStorageWrapper: LocalStorageWrapper) {
-    this.selectedLanguage = this.localStorageWrapper.getObject(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
+  constructor(private translateService: TranslateService, private DataStore: DataStore) {
+    this.selectedLanguage = this.DataStore.getObject(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
 
     this.translateService.addLangs(['ar', 'en', 'fa', 'fa_AF', 'ku', 'ps', 'sv', 'ti']);
     this.translateService.setDefaultLang('en');
@@ -21,7 +21,7 @@ export class TranslationService {
 
   public setLanguage(language: Language) {
     this.selectedLanguage = language;
-    this.localStorageWrapper.setObject(this.storageSelectedLanguageKey, language);
+    this.DataStore.setObject(this.storageSelectedLanguageKey, language);
     this.translateService.use(language.languageCode);
     this.languageChange.emit();
   }

--- a/src/app/services/translation.service.ts
+++ b/src/app/services/translation.service.ts
@@ -10,7 +10,7 @@ export class TranslationService {
   private languageChange: EventEmitter<any> = new EventEmitter();
 
   constructor(private translateService: TranslateService, private dataStore: DataStore) {
-    this.selectedLanguage = this.dataStore.getObject(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
+    this.selectedLanguage = this.dataStore.get(this.storageSelectedLanguageKey) || new Language({id: '156', lang_code: 'sv', local_name: 'Swedish'});
 
     this.translateService.addLangs(['ar', 'en', 'fa', 'fa_AF', 'ku', 'ps', 'sv', 'ti']);
     this.translateService.setDefaultLang('en');
@@ -21,7 +21,7 @@ export class TranslationService {
 
   public setLanguage(language: Language) {
     this.selectedLanguage = language;
-    this.dataStore.setObject(this.storageSelectedLanguageKey, language);
+    this.dataStore.set(this.storageSelectedLanguageKey, language);
     this.translateService.use(language.languageCode);
     this.languageChange.emit();
   }

--- a/src/app/services/user-manager.service.ts
+++ b/src/app/services/user-manager.service.ts
@@ -10,17 +10,17 @@ export class UserManager {
   constructor(private dataStore: DataStore) { }
 
   getUserId() {
-    let authorizationData = this.dataStore.getObject(this.storageAuthorizationData);
+    let authorizationData = this.dataStore.get(this.storageAuthorizationData);
     return authorizationData && authorizationData.user_id;
   }
 
   saveAuthorizationData(data) {
-    this.dataStore.setObject(this.storageAuthorizationData, data);
+    this.dataStore.set(this.storageAuthorizationData, data);
   }
 
   deleteUser() {
     this.user = null;
-    this.dataStore.removeObject(this.storageAuthorizationData);
+    this.dataStore.remove(this.storageAuthorizationData);
   }
 
   saveUser(user: User) {

--- a/src/app/services/user-manager.service.ts
+++ b/src/app/services/user-manager.service.ts
@@ -7,20 +7,20 @@ export class UserManager {
   private storageAuthorizationData: string = 'authorizationData';
   private user: User;
 
-  constructor(private DataStore: DataStore) { }
+  constructor(private dataStore: DataStore) { }
 
   getUserId() {
-    let authorizationData = this.DataStore.getObject(this.storageAuthorizationData);
+    let authorizationData = this.dataStore.getObject(this.storageAuthorizationData);
     return authorizationData && authorizationData.user_id;
   }
 
   saveAuthorizationData(data) {
-    this.DataStore.setObject(this.storageAuthorizationData, data);
+    this.dataStore.setObject(this.storageAuthorizationData, data);
   }
 
   deleteUser() {
     this.user = null;
-    this.DataStore.removeObject(this.storageAuthorizationData);
+    this.dataStore.removeObject(this.storageAuthorizationData);
   }
 
   saveUser(user: User) {

--- a/src/app/services/user-manager.service.ts
+++ b/src/app/services/user-manager.service.ts
@@ -20,7 +20,7 @@ export class UserManager {
 
   deleteUser() {
     this.user = null;
-    this.DataStore.remove(this.storageAuthorizationData);
+    this.DataStore.removeObject(this.storageAuthorizationData);
   }
 
   saveUser(user: User) {

--- a/src/app/services/user-manager.service.ts
+++ b/src/app/services/user-manager.service.ts
@@ -1,26 +1,26 @@
 import { Injectable } from '@angular/core';
 import {User} from '../models/user';
-import {LocalStorageWrapper} from './local-storage-wrapper.service';
+import {DataStore} from './data-store.service';
 
 @Injectable()
 export class UserManager {
   private storageAuthorizationData: string = 'authorizationData';
   private user: User;
 
-  constructor(private localStorageWrapper: LocalStorageWrapper) { }
+  constructor(private DataStore: DataStore) { }
 
   getUserId() {
-    let authorizationData = this.localStorageWrapper.getObject(this.storageAuthorizationData);
+    let authorizationData = this.DataStore.getObject(this.storageAuthorizationData);
     return authorizationData && authorizationData.user_id;
   }
 
   saveAuthorizationData(data) {
-    this.localStorageWrapper.setObject(this.storageAuthorizationData, data);
+    this.DataStore.setObject(this.storageAuthorizationData, data);
   }
 
   deleteUser() {
     this.user = null;
-    this.localStorageWrapper.remove(this.storageAuthorizationData);
+    this.DataStore.remove(this.storageAuthorizationData);
   }
 
   saveUser(user: User) {

--- a/src/app/utils/storage/cookie-storage.ts
+++ b/src/app/utils/storage/cookie-storage.ts
@@ -42,7 +42,7 @@ export class CookieStorage implements StorageInterface {
     return true;
   }
 
-  isCachable(): boolean {
+  supportsCaching(): boolean {
     return false;
   }
 

--- a/src/app/utils/storage/cookie-storage.ts
+++ b/src/app/utils/storage/cookie-storage.ts
@@ -1,0 +1,99 @@
+import {StorageInterface} from './storage-interface';
+
+export class CookieStorage implements StorageInterface {
+  private data: Object = {};
+  private DOM: any;
+
+  constructor(document: any) {
+    this.DOM = document;
+
+    // initialise if there's already data
+    this.data = this.getData();
+  }
+
+  clear(): void {
+    this.data = {};
+    this.clearData();
+  }
+
+  getItem(key: string): string {
+    return this.data[key] === undefined ? null : this.data[key];
+  }
+
+  removeItem(key: string): string {
+    const oldValue = this.data[key];
+    delete this.data[key];
+
+    this.setData(this.data);
+
+    return oldValue;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data[key] = value;
+    this.setData(this.data);
+  }
+
+  persistsRefresh(): boolean {
+    return true;
+  }
+
+  persistsSession(): boolean {
+    return true;
+  }
+
+  isCachable(): boolean {
+    return false;
+  }
+
+  private createCookie(name: string, value: string, days: number): void {
+    let expires;
+
+    if (days) {
+      const date = new Date();
+      date.setTime(date.getTime() + this.daysToMillis(days));
+      expires = '; expires=' + date.toUTCString();
+    } else {
+      expires = '';
+    }
+
+    this.DOM.cookie = name + '=' + value + expires + '; path=/';
+  }
+
+  private readCookie(name: string) {
+    const nameEQ: string = name + '=';
+    const cookieParts: Array<string> = this.DOM.cookie.split(';');
+    let data: string = null;
+
+    cookieParts.forEach((c: string) => {
+      while (c.charAt(0) == ' ') {
+        c = c.substring(1, c.length);
+      }
+
+      if (c.indexOf(nameEQ) == 0) {
+        data = c.substring(nameEQ.length, c.length);
+        return;
+      }
+    });
+
+    return data;
+  }
+
+  private setData(data: any) {
+    data = JSON.stringify(data);
+    this.createCookie('localStorage', data, 365);
+  }
+
+  private clearData(): void {
+    this.createCookie('localStorage', '', 365);
+  }
+
+  private getData(): Object {
+    const data = this.readCookie('localStorage');
+    return data ? JSON.parse(data) : {};
+  }
+
+  private daysToMillis(days: number): number {
+    return days * 24 * 60 * 60 * 1000;
+  }
+}

--- a/src/app/utils/storage/local-storage.ts
+++ b/src/app/utils/storage/local-storage.ts
@@ -34,7 +34,7 @@ export class LocalStorage implements StorageInterface {
     return true;
   }
 
-  isCachable(): boolean {
+  supportsCaching(): boolean {
     return true;
   }
 }

--- a/src/app/utils/storage/local-storage.ts
+++ b/src/app/utils/storage/local-storage.ts
@@ -1,0 +1,40 @@
+import {StorageInterface} from './storage-interface';
+
+export class LocalStorage implements StorageInterface {
+  private store: any;
+
+  constructor(store: any) {
+    this.store = store;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.setItem(key, value);
+  }
+
+  getItem(key: string): string {
+    return this.store.getItem(key);
+  }
+
+  removeItem(key: string): string {
+    const oldValue = this.getItem(key);
+    this.store.removeItem(key);
+
+    return oldValue;
+  }
+
+  persistsRefresh(): boolean {
+    return true;
+  }
+
+  persistsSession(): boolean {
+    return true;
+  }
+
+  isCachable(): boolean {
+    return true;
+  }
+}

--- a/src/app/utils/storage/memory-storage.ts
+++ b/src/app/utils/storage/memory-storage.ts
@@ -1,0 +1,36 @@
+import {StorageInterface} from './storage-interface';
+
+export class MemoryStorage implements StorageInterface {
+  private items: Object = {};
+
+  clear(): void {
+    this.items = {};
+  }
+
+  setItem(key: string, value: string): void {
+    this.items[key] = value;
+  }
+
+  getItem(key: string): string {
+    return this.items[key];
+  }
+
+  removeItem(key: string): string {
+    const oldValue = this.getItem(key);
+    this.setItem(key, null);
+
+    return oldValue;
+  }
+
+  persistsRefresh(): boolean {
+    return false;
+  }
+
+  persistsSession(): boolean {
+    return false;
+  }
+
+  isCachable(): boolean {
+    return true;
+  }
+}

--- a/src/app/utils/storage/memory-storage.ts
+++ b/src/app/utils/storage/memory-storage.ts
@@ -30,7 +30,7 @@ export class MemoryStorage implements StorageInterface {
     return false;
   }
 
-  isCachable(): boolean {
+  supportsCaching(): boolean {
     return true;
   }
 }

--- a/src/app/utils/storage/session-storage.ts
+++ b/src/app/utils/storage/session-storage.ts
@@ -1,0 +1,40 @@
+import {StorageInterface} from './storage-interface';
+
+export class SessionStorage implements StorageInterface {
+  private store: any;
+
+  constructor(sessionStore: any) {
+    this.store = sessionStore;
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  getItem(key: string) {
+    return this.store.getItem(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.store.setItem(key, value);
+  }
+
+  removeItem(key: string): string {
+    const oldValue = this.getItem(key);
+    sessionStorage.removeItem(key);
+
+    return oldValue;
+  }
+
+  persistsRefresh(): boolean {
+    return true;
+  }
+
+  persistsSession(): boolean {
+    return false;
+  }
+
+  isCachable(): boolean {
+    return true;
+  }
+}

--- a/src/app/utils/storage/session-storage.ts
+++ b/src/app/utils/storage/session-storage.ts
@@ -34,7 +34,7 @@ export class SessionStorage implements StorageInterface {
     return false;
   }
 
-  isCachable(): boolean {
+  supportsCaching(): boolean {
     return true;
   }
 }

--- a/src/app/utils/storage/storage-interface.ts
+++ b/src/app/utils/storage/storage-interface.ts
@@ -3,7 +3,7 @@ export interface StorageInterface {
   getItem(key: string): string;
   setItem(key: string, value: string): void;
   removeItem(key: string): string;
-  isCachable(): boolean;
+  supportsCaching(): boolean;
   persistsRefresh(): boolean;
   persistsSession(): boolean;
 }

--- a/src/app/utils/storage/storage-interface.ts
+++ b/src/app/utils/storage/storage-interface.ts
@@ -1,0 +1,9 @@
+export interface StorageInterface {
+  clear(): void;
+  getItem(key: string): string;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): string;
+  isCachable(): boolean;
+  persistsRefresh(): boolean;
+  persistsSession(): boolean;
+}


### PR DESCRIPTION
## `DataStore` (formerly `LocalStorageWrapper`)

- Adds `SessionStorage` class
- Adds `CookieStorage` class
- Adds `persistsRefresh`, `presistsSession`, `supportsCaching ` methods to StorageInterface protocol
- `StorageInterface.removeItem` returns old value
- Decrease `DataStore`s public surface area
- Split storage implementations to separate files

## CookieStore

`CookieStore` is the only option that works with Safari Private Browsing, but has _very_ limited storage size (4kB) compared to the other options (~5-10MB).
4kb is enough for auth data and a bit more, but we can't use it as a cache. 

Each store type has a couple of methods that indicate what capabilities they have (see [`StorageInterface`](https://github.com/justarrived/just-match-web/blob/633c2caa5c2e47681a716b6f5a00025b705268ae/src/app/utils/storage/storage-interface.ts)), namely:  `supportsCaching()`, `persistsRefresh()`, `persistsSession()`.

## Questions

* What do you think about the name `DataStore`, is it too generic?
* How do we make sure that the max size of `CookieStore`s 4kb doesn't become a nasty bug in the future? (or can we at least make sure that it throws an error?)
