### PR TITLE
Cookie information

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -106,6 +106,7 @@
   </div>
 </div>
 <section class="app-content-container">
+  <cookie-bar></cookie-bar>
   <router-outlet></router-outlet>
 </section>
 <footer class="container-fluid footer">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import {FaqComponent} from './views/faq/faq.component';
 import {ContactComponent} from './views/contact/contact.component';
 import {ContactConfirmationComponent} from './views/contact/confirmation/contact-confirmation.component';
 import {ConfirmationComponent} from './views/confirmation/confirmation.component';
+import {CookiesAboutComponent} from './views/cookies-about/cookies-about.component';
 import {CandidateComponent} from './views/candidate/candidate.component';
 import {CandidateStateStatusBarComponent} from './components/candidate-state-status-bar/candidate-state-status-bar.component';
 import {CandidatesComponent} from './views/candidates/candidates.component';
@@ -80,6 +81,7 @@ import {TranslationItemComponent} from './components/translation-item/translatio
     ContactComponent,
     ContactConfirmationComponent,
     ConfirmationComponent,
+    CookiesAboutComponent,
     CandidatesComponent,
     CandidateComponent,
     CandidateStateStatusBarComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import {ContactComponent} from './views/contact/contact.component';
 import {ContactConfirmationComponent} from './views/contact/confirmation/contact-confirmation.component';
 import {ConfirmationComponent} from './views/confirmation/confirmation.component';
 import {CookiesAboutComponent} from './views/cookies-about/cookies-about.component';
+import {CookieBarComponent} from './components/cookie-bar/cookie-bar.component';
 import {CandidateComponent} from './views/candidate/candidate.component';
 import {CandidateStateStatusBarComponent} from './components/candidate-state-status-bar/candidate-state-status-bar.component';
 import {CandidatesComponent} from './views/candidates/candidates.component';
@@ -82,6 +83,7 @@ import {TranslationItemComponent} from './components/translation-item/translatio
     ContactConfirmationComponent,
     ConfirmationComponent,
     CookiesAboutComponent,
+    CookieBarComponent,
     CandidatesComponent,
     CandidateComponent,
     CandidateStateStatusBarComponent,

--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -13,6 +13,7 @@ import {JobCreateComponent} from './views/jobs/job-create/job-create.component';
 import {JobsComponent} from './views/jobs/jobs.component';
 import {JobDetailsComponent} from './views/job-details/job-details.component';
 import {ConfirmationComponent} from './views/confirmation/confirmation.component';
+import {CookiesAboutComponent} from './views/cookies-about/cookies-about.component';
 import {CandidateComponent} from './views/candidate/candidate.component';
 import {CandidatesComponent} from './views/candidates/candidates.component';
 import {MyJobsComponent} from './views/my-jobs/my-jobs.component';
@@ -26,6 +27,7 @@ const routes: Routes = [
   { path: 'contact', component: ContactComponent, data: { title: 'Contact' } },
   { path: 'contact/confirmation', component: ContactConfirmationComponent, data: { title: 'Contact Confirmation' } },
   { path: 'confirmation/:type', component: ConfirmationComponent },
+  { path: 'cookies_about', component: CookiesAboutComponent },
   { path: 'job/create', component: JobCreateComponent, data: { roles: ['company'] }, canActivate: [AuthGuard] },
   { path: 'jobs/:page', component: JobsComponent },
   { path: 'job/:id/candidate/:userJobId', component: CandidateComponent },

--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -27,7 +27,7 @@ const routes: Routes = [
   { path: 'contact', component: ContactComponent, data: { title: 'Contact' } },
   { path: 'contact/confirmation', component: ContactConfirmationComponent, data: { title: 'Contact Confirmation' } },
   { path: 'confirmation/:type', component: ConfirmationComponent },
-  { path: 'cookies_about', component: CookiesAboutComponent },
+  { path: 'cookies-about', component: CookiesAboutComponent },
   { path: 'job/create', component: JobCreateComponent, data: { roles: ['company'] }, canActivate: [AuthGuard] },
   { path: 'jobs/:page', component: JobsComponent },
   { path: 'job/:id/candidate/:userJobId', component: CandidateComponent },

--- a/src/app/components/cookie-bar/cookie-bar.component.html
+++ b/src/app/components/cookie-bar/cookie-bar.component.html
@@ -1,0 +1,11 @@
+<div class="cookie-message" *ngIf="checkCookiesConsent()">
+  <div class="cookie-message-inner">
+    <p class="fs-m0">
+      {{'cookies.description' | translate}}
+      <a class="read-more fs-m0" routerLink="/cookies-about">{{'cookies.read_more' | translate}}</a>
+    </p>
+    <div class="cookies-button">
+      <button type="button" class="btn-secondary-light btn-small btn fs-m0" (click)="acceptCookiesConsent()">Accept</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/cookie-bar/cookie-bar.component.scss
+++ b/src/app/components/cookie-bar/cookie-bar.component.scss
@@ -1,0 +1,54 @@
+@import '../../styles/variables';
+@import '../../styles/buttons';
+
+.cookie-message {
+  text-align: center;
+  background: $color-blue-500;
+  color: $white;
+  padding: 20px 32px;
+  @media screen and (min-width: $sm-device-width) {
+    text-align: left;
+  }
+
+  .cookie-message-inner {
+    max-width: 784px;
+    margin: 0 auto;
+    @media screen and (min-width: $sm-device-width) {
+      display: flex;
+    }
+
+    p {
+      margin: auto;
+
+      .read-more {
+        display: block;
+        margin: 15px 0;
+        color: inherit;
+        text-decoration: underline;
+
+        &:hover {
+          text-decoration: none;
+        }
+        @media screen and (min-width: $sm-device-width) {
+          display: inline;
+          margin: 0;
+        }
+      }
+    }
+
+    .cookies-button {
+      @media screen and (min-width: $sm-device-width) {
+        margin: auto;
+      }
+
+      button {
+        background-color: $color-blue-500;
+
+        &:hover {
+          background-color: $color-blue-700;
+          color: inherit;
+        }
+      }
+    }
+  }
+}

--- a/src/app/components/cookie-bar/cookie-bar.component.scss
+++ b/src/app/components/cookie-bar/cookie-bar.component.scss
@@ -48,6 +48,12 @@
           background-color: $color-blue-700;
           color: inherit;
         }
+
+        &:active {
+          background-color: $color-blue-700;
+          color: inherit;
+          border-color: inherit;
+        }
       }
     }
   }

--- a/src/app/components/cookie-bar/cookie-bar.component.ts
+++ b/src/app/components/cookie-bar/cookie-bar.component.ts
@@ -1,0 +1,23 @@
+import {Component} from '@angular/core';
+import {DataStore} from '../../services/data-store.service';
+
+
+@Component({
+  selector: 'cookie-bar',
+  templateUrl: './cookie-bar.component.html',
+  styleUrls: ['./cookie-bar.component.scss']
+})
+export class CookieBarComponent {
+  private cookiesConsentData: string = 'cookiesConsentData';
+
+  constructor(private dataStore: DataStore) {
+  }
+
+  checkCookiesConsent(): boolean {
+    return (this.dataStore.get(this.cookiesConsentData) !== true);
+  }
+
+  acceptCookiesConsent() {
+    this.dataStore.set(this.cookiesConsentData, true);
+  }
+}

--- a/src/app/views/cookies-about/cookies-about.component.html
+++ b/src/app/views/cookies-about/cookies-about.component.html
@@ -10,7 +10,7 @@
   </div>
 
   <div class="cookies-about-container row">
-    <p>{{ 'cookies.info.description' | translate}}</p>
+    <p class="fs-m0">{{ 'cookies.info.description' | translate}}</p>
   </div>
 
 </div>

--- a/src/app/views/cookies-about/cookies-about.component.html
+++ b/src/app/views/cookies-about/cookies-about.component.html
@@ -1,0 +1,16 @@
+<div class="container-fluid">
+
+  <div class="cookies-about-header row">
+    <!-- All Questions -->
+    <div class="col-xs-12">
+      <h3>
+        {{ 'cookies.info.title' | translate }}
+      </h3>
+    </div>
+  </div>
+
+  <div class="cookies-about-container row">
+    <p>{{ 'cookies.info.description' | translate}}</p>
+  </div>
+
+</div>

--- a/src/app/views/cookies-about/cookies-about.component.scss
+++ b/src/app/views/cookies-about/cookies-about.component.scss
@@ -1,0 +1,23 @@
+@import '../../styles/variables';
+
+.cookies-about-header {
+  background-color: $color-primary-cerise;
+  padding: 1em 0;
+
+  h3 {
+    position: relative;
+    top: 5px;
+    color: $white;
+  }
+
+}
+
+.cookies-about-container {
+  background-color: $default-bg-color;
+  padding: 20px;
+  p {
+    margin: 0 0 10px;
+    font-weight: 400;
+    font-size: 14px;
+  }
+}

--- a/src/app/views/cookies-about/cookies-about.component.scss
+++ b/src/app/views/cookies-about/cookies-about.component.scss
@@ -17,7 +17,5 @@
   padding: 20px;
   p {
     margin: 0 0 10px;
-    font-weight: 400;
-    font-size: 14px;
   }
 }

--- a/src/app/views/cookies-about/cookies-about.component.ts
+++ b/src/app/views/cookies-about/cookies-about.component.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './cookies-about.component.html',
+  styleUrls: ['./cookies-about.component.scss']
+})
+export class CookiesAboutComponent {
+
+  constructor() {
+  }
+}


### PR DESCRIPTION
Had to put the cookie-bar below the navbar now that it is sticky to top.
Otherwise the content which is adjusted to begin below the navbar height would be overlapped.

Any idea on how to place it on top of sticky navbar or is it fine like this?
Probably not a popular idea to let the cookie-bar follow the viewer like the navbar anyways.


![cookie-bar](https://cloud.githubusercontent.com/assets/3455771/21247409/7bdd2f24-c32f-11e6-9773-78573013a778.png)
