### PR TITLE
Login design and forgot password page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {AutocompleteDropdownListItemComponent} from './components/autocomplete-d
 import {AutocompleteDropdownComponent} from './components/autocomplete-dropdown/autocomplete-dropdown.component';
 import {LanguageProxy} from './services/proxy/language-proxy.service';
 import {LoginComponent} from './views/login/login.component';
+import {ForgotPasswordComponent} from './views/forgot-password/forgot-password.component';
 import {UserManager} from './services/user-manager.service';
 import {JobCreateComponent} from './views/jobs/job-create/job-create.component';
 import {JobPreviewComponent} from './components/job-preview/job-preview.component';
@@ -68,6 +69,7 @@ import {TranslationItemComponent} from './components/translation-item/translatio
     AutocompleteDropdownListItemComponent,
     AutocompleteDropdownComponent,
     LoginComponent,
+    ForgotPasswordComponent,
     JobCreateComponent,
     JobPreviewComponent,
     JobsComponent,

--- a/src/app/app.routing.module.ts
+++ b/src/app/app.routing.module.ts
@@ -6,6 +6,7 @@ import {AuthGuard} from './services/auth-guard.service';
 import {UserRegisterComponent} from './views/user/user-register/user-register.component';
 import {UserSettingsComponent} from './views/user/user-settings/user-settings.component';
 import {LoginComponent} from './views/login/login.component';
+import {ForgotPasswordComponent} from './views/forgot-password/forgot-password.component';
 import {FaqComponent} from './views/faq/faq.component';
 import {ContactComponent} from './views/contact/contact.component';
 import {ContactConfirmationComponent} from './views/contact/confirmation/contact-confirmation.component';
@@ -22,6 +23,7 @@ const routes: Routes = [
   { path: 'home', component: HomeComponent },
   { path: 'about', component: AboutComponent, data: { title: 'About' }, canActivate: [AuthGuard] },
   { path: 'login', component: LoginComponent, data: { title: 'Login' } },
+  { path: 'forgot-password', component: ForgotPasswordComponent },
   { path: 'faq', component: FaqComponent, data: { title: 'Questions and Answers' } },
   { path: 'contact', component: ContactComponent, data: { title: 'Contact' } },
   { path: 'contact/confirmation', component: ContactConfirmationComponent, data: { title: 'Contact Confirmation' } },

--- a/src/app/services/proxy/user-proxy.service.ts
+++ b/src/app/services/proxy/user-proxy.service.ts
@@ -48,4 +48,10 @@ export class UserProxy {
   createFrilansFinans(userId, bankAccount) {
     return this.apiCall.post('users/' + userId + '/frilans-finans', bankAccount);
   }
+
+  resetPassword(email_or_phone: string) {
+    return this.apiCall.post('users/reset-password', {
+      'email_or_phone': email_or_phone
+    });
+  }
 }

--- a/src/app/views/confirmation/confirmation.component.html
+++ b/src/app/views/confirmation/confirmation.component.html
@@ -65,4 +65,15 @@
       </div>
     </div>
   </div>
+  <div *ngIf="type === 'password-reset-link-sent'" class="confirmation-item table text-center">
+    <a class="close-button" routerLink="/forgot-password"></a>
+    <div class="table-row">
+      <div class="table-cell">
+        <div class="item-icon"><i class="fa fa-envelope fa-5x" aria-hidden="true"></i></div>
+        <div class="item-title">{{'login.forgot_password.confirmation' | translate}}</div>
+        <div class="item-content">{{'login.forgot_password.confirmation.description' | translate}}</div>
+        <div class="button-container"><a class="btn-primary btn-large btn" routerLink="/forgot-password">{{'common.back' | translate}}</a></div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/views/forgot-password/forgot-password.component.html
+++ b/src/app/views/forgot-password/forgot-password.component.html
@@ -1,0 +1,28 @@
+<div class="container-fluid">
+
+  <div class="forgot-password-header row">
+    <!-- All Questions -->
+    <div class="col-xs-12">
+      <h3>
+        {{'login.forgot_password' | translate}}
+      </h3>
+    </div>
+  </div>
+
+  <div class="forgot-password-form-container">
+
+    <form [formGroup]="forgotPasswordForm" (ngSubmit)="submitForm(forgotPasswordForm.value)">
+      <div class="form-group material-group forgot-password-input-container" [ngClass]="{'has-error':!forgotPasswordForm.controls['email_or_phone'].valid && forgotPasswordForm.controls['email_or_phone'].touched}">
+        <input class="form-control material-input fs-m0" type="text" placeholder="{{'login.form.email_or_phone' | translate}}" [formControl]="forgotPasswordForm.controls['email_or_phone']">
+
+        <div *ngIf="forgotPasswordForm.controls['email_or_phone'].hasError('required') && forgotPasswordForm.controls['email_or_phone'].touched" class="alert alert-danger">{{'login.form.email_or_phone.validation' | translate}}.</div>
+      </div>
+      <div class="form-group forgot-password-button-container">
+        <div *ngIf="displayErrorMessage" class="error-message fs-m0">{{'login.forgot_password.error' | translate}}</div>
+        <button type="submit" [disabled]="!forgotPasswordForm.valid" class="btn-primary btn-small btn">{{'common.submit' | translate}}</button>
+        <a class="fs-m0" routerLink="/login">{{'common.login' | translate}}</a>
+      </div>
+    </form>
+
+  </div>
+</div>

--- a/src/app/views/forgot-password/forgot-password.component.scss
+++ b/src/app/views/forgot-password/forgot-password.component.scss
@@ -1,7 +1,7 @@
 @import '../../styles/variables';
 @import '../../styles/buttons';
 
-.login-header {
+.forgot-password-header {
   background-color: $color-primary-cerise;
   padding: 1em 0;
 
@@ -13,19 +13,19 @@
 
 }
 
-.login-form-container {
+.forgot-password-form-container {
   background-color: $default-bg-color;
   margin-right: -15px;
   margin-left: -15px;
   padding-top: 50px;
 
-  .login-input-container {
+  .forgot-password-input-container {
     max-width: 500px;
     margin: 0 auto;
     padding-bottom: 1.5em;
   }
 
-  .login-button-container {
+  .forgot-password-button-container {
     max-width: 500px;
     margin: 0 auto;
     padding-bottom: 1.5em;

--- a/src/app/views/forgot-password/forgot-password.component.ts
+++ b/src/app/views/forgot-password/forgot-password.component.ts
@@ -1,0 +1,27 @@
+import {Component} from '@angular/core';
+import {FormGroup, FormBuilder, Validators} from '@angular/forms';
+import {UserProxy} from '../../services/proxy/user-proxy.service';
+import {Router} from '@angular/router';
+
+@Component({
+    templateUrl: './forgot-password.component.html',
+    styleUrls: ['./forgot-password.component.scss'],
+})
+export class ForgotPasswordComponent {
+  forgotPasswordForm: FormGroup;
+  displayErrorMessage: boolean;
+
+  constructor(private userProxy: UserProxy, private router: Router, private formBuilder: FormBuilder) {
+    this.forgotPasswordForm = formBuilder.group({
+      'email_or_phone': [null, Validators.compose([Validators.required])]
+    })
+  }
+
+  submitForm(value: any) {
+    this.userProxy.resetPassword(value.email_or_phone)
+      .then(result => this.router.navigate(['/confirmation/password-reset-link-sent']))
+      .catch(errors => {
+        this.displayErrorMessage = true;
+      });
+  }
+}

--- a/src/app/views/login/login.component.html
+++ b/src/app/views/login/login.component.html
@@ -1,16 +1,33 @@
 <div class="container-fluid">
-  <div class="row">
+
+  <div class="contact-header row">
+    <!-- All Questions -->
     <div class="col-xs-12">
-
-      <div class="material-group">
-        <input [(ngModel)]="email" type="text" class="material-input">
-      </div>
-
-      <div class="material-group">
-        <input [(ngModel)]="password" type="password" class="material-input">
-      </div>
-
-      <button (click)="onLoginButtonClick()">Login</button>
+      <h3>
+        {{'login.title' | translate}}
+      </h3>
     </div>
+  </div>
+
+  <div class="login-form-container">
+
+    <form [formGroup]="loginForm" (ngSubmit)="submitForm(loginForm.value)">
+      <div class="form-group material-group login-input-container" [ngClass]="{'has-error':!loginForm.controls['email'].valid && loginForm.controls['email'].touched}">
+        <input class="form-control material-input fs-m0" type="text" placeholder="{{'login.form.email_or_phone' | translate}}" [formControl]="loginForm.controls['email']">
+
+        <div *ngIf="loginForm.controls['email'].hasError('required') && loginForm.controls['email'].touched" class="alert alert-danger">{{'login.form.email_or_phone.validation' | translate}}.</div>
+      </div>
+      <div class="form-group  material-group login-input-container" [ngClass]="{'has-error':!loginForm.controls['password'].valid && loginForm.controls['password'].touched}">
+        <input class="form-control material-input fs-m0" type="password" placeholder="{{'login.form.password' | translate}}" [formControl]="loginForm.controls['password']">
+
+        <div *ngIf="loginForm.controls['password'].hasError('required') && loginForm.controls['password'].touched" class="alert alert-danger">{{'login.form.password.validation' | translate}}.</div>
+      </div>
+      <div class="form-group login-button-container">
+        <div *ngIf="error_message" class="error-message fs-m0">{{error_message}}</div>
+        <button type="submit" [disabled]="!loginForm.valid" class="btn-primary btn-small btn">{{'common.login' | translate}}</button>
+        <a class="forgot-password fs-m0" routerLink="/forgot_password">{{'login.forgot_password' | translate}}</a>
+      </div>
+    </form>
+
   </div>
 </div>

--- a/src/app/views/login/login.component.html
+++ b/src/app/views/login/login.component.html
@@ -1,6 +1,6 @@
 <div class="container-fluid">
 
-  <div class="contact-header row">
+  <div class="login-header row">
     <!-- All Questions -->
     <div class="col-xs-12">
       <h3>
@@ -12,10 +12,10 @@
   <div class="login-form-container">
 
     <form [formGroup]="loginForm" (ngSubmit)="submitForm(loginForm.value)">
-      <div class="form-group material-group login-input-container" [ngClass]="{'has-error':!loginForm.controls['email'].valid && loginForm.controls['email'].touched}">
-        <input class="form-control material-input fs-m0" type="text" placeholder="{{'login.form.email_or_phone' | translate}}" [formControl]="loginForm.controls['email']">
+      <div class="form-group material-group login-input-container" [ngClass]="{'has-error':!loginForm.controls['email_or_phone'].valid && loginForm.controls['email_or_phone'].touched}">
+        <input class="form-control material-input fs-m0" type="text" placeholder="{{'login.form.email_or_phone' | translate}}" [formControl]="loginForm.controls['email_or_phone']">
 
-        <div *ngIf="loginForm.controls['email'].hasError('required') && loginForm.controls['email'].touched" class="alert alert-danger">{{'login.form.email_or_phone.validation' | translate}}.</div>
+        <div *ngIf="loginForm.controls['email_or_phone'].hasError('required') && loginForm.controls['email_or_phone'].touched" class="alert alert-danger">{{'login.form.email_or_phone.validation' | translate}}.</div>
       </div>
       <div class="form-group  material-group login-input-container" [ngClass]="{'has-error':!loginForm.controls['password'].valid && loginForm.controls['password'].touched}">
         <input class="form-control material-input fs-m0" type="password" placeholder="{{'login.form.password' | translate}}" [formControl]="loginForm.controls['password']">
@@ -23,9 +23,9 @@
         <div *ngIf="loginForm.controls['password'].hasError('required') && loginForm.controls['password'].touched" class="alert alert-danger">{{'login.form.password.validation' | translate}}.</div>
       </div>
       <div class="form-group login-button-container">
-        <div *ngIf="error_message" class="error-message fs-m0">{{error_message}}</div>
+        <div *ngIf="errorMessage" class="error-message fs-m0">{{errorMessage}}</div>
         <button type="submit" [disabled]="!loginForm.valid" class="btn-primary btn-small btn">{{'common.login' | translate}}</button>
-        <a class="forgot-password fs-m0" routerLink="/forgot_password">{{'login.forgot_password' | translate}}</a>
+        <a class="forgot-password fs-m0" routerLink="/forgot-password">{{'login.forgot_password' | translate}}</a>
       </div>
     </form>
 

--- a/src/app/views/login/login.component.scss
+++ b/src/app/views/login/login.component.scss
@@ -1,0 +1,48 @@
+@import '../../styles/variables';
+@import '../../styles/buttons';
+
+.contact-header {
+  background-color: $color-primary-cerise;
+  padding: 1em 0;
+
+  h3 {
+    position: relative;
+    top: 5px;
+    color: $white;
+  }
+
+}
+
+.login-form-container {
+  background-color: $default-bg-color;
+  margin-right: -15px;
+  margin-left: -15px;
+  padding-top: 50px;
+
+  .login-input-container {
+    max-width: 500px;
+    margin: 0 auto;
+    padding-bottom: 1.5em;
+  }
+
+  .login-button-container {
+    max-width: 500px;
+    margin: 0 auto;
+    padding-bottom: 1.5em;
+    text-align: center;
+    .error-message {
+      color: $color-cerise-500;
+    }
+
+    button {
+      display: block;
+      margin: 15px auto 30px;
+      min-width: 200px;
+    }
+
+    a {
+      color: $color-accent-main;
+      font-weight: 600;
+    }
+  }
+}

--- a/src/app/views/login/login.component.ts
+++ b/src/app/views/login/login.component.ts
@@ -1,18 +1,32 @@
 import {Component} from '@angular/core';
+import {FormGroup, FormBuilder, Validators} from '@angular/forms';
 import {AuthManager} from '../../services/auth-manager.service';
 import {Router} from '@angular/router';
 
 @Component({
-    templateUrl: './login.component.html'
+    templateUrl: './login.component.html',
+    styleUrls: ['./login.component.scss'],
 })
 export class LoginComponent {
-  email: string;
-  password: string;
+  loginForm: FormGroup;
+  error_message: string;
 
-  constructor(private authManager: AuthManager, private router: Router) { }
-
-  onLoginButtonClick() {
-    this.authManager.logUser(this.email, this.password).then(result => this.router.navigate(['/home']));
+  constructor(private authManager: AuthManager, private router: Router, private formBuilder: FormBuilder) {
+    this.loginForm = formBuilder.group({
+      'email': [null, Validators.compose([Validators.required])],
+      'password': [null, Validators.compose([Validators.required])]
+    })
   }
 
+  submitForm(value: any) {
+    this.authManager.logUser(value.email, value.password)
+      .then(result => this.router.navigate(['/home']))
+      .catch(errors => {
+        if (errors.details) {
+          this.error_message = errors.details.password;
+        } else {
+          console.log(errors);
+        }
+      });
+  }
 }

--- a/src/app/views/login/login.component.ts
+++ b/src/app/views/login/login.component.ts
@@ -9,21 +9,21 @@ import {Router} from '@angular/router';
 })
 export class LoginComponent {
   loginForm: FormGroup;
-  error_message: string;
+  errorMessage: string;
 
   constructor(private authManager: AuthManager, private router: Router, private formBuilder: FormBuilder) {
     this.loginForm = formBuilder.group({
-      'email': [null, Validators.compose([Validators.required])],
+      'email_or_phone': [null, Validators.compose([Validators.required])],
       'password': [null, Validators.compose([Validators.required])]
     })
   }
 
   submitForm(value: any) {
-    this.authManager.logUser(value.email, value.password)
+    this.authManager.logUser(value.email_or_phone, value.password)
       .then(result => this.router.navigate(['/home']))
       .catch(errors => {
         if (errors.details) {
-          this.error_message = errors.details.password;
+          this.errorMessage = errors.details.password;
         } else {
           console.log(errors);
         }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -77,6 +77,8 @@
   "login.form.password.validation": "Password missing",
   "login.forgot_password": "Forgotten your password?",
   "login.forgot_password.error": "Unfortunately, your password could not be updated. Click here to try again",
+  "login.forgot_password.confirmation": "A password reset message has been sent to you!",
+  "login.forgot_password.confirmation.description": "If you follow the link provided in the message you can thereafter set a new password.",
   "login.create.assignment.title": "Create new job",
   "login.create.assignment.description": "You need to create a profile before you can create a job",
   "login.apply.assignment.title": "Search jobs",


### PR DESCRIPTION
Implementation of login and forgot password page.

Note: There is currently a bug in the API as it will not throw an error when trying to reset a password for a non existant email or phone number.

![login](https://cloud.githubusercontent.com/assets/3455771/21282565/a741ba96-c3f6-11e6-9861-64348ef6f49c.png)
![forgot](https://cloud.githubusercontent.com/assets/3455771/21282567/a745a28c-c3f6-11e6-99e5-e698020258b1.png)
![conf](https://cloud.githubusercontent.com/assets/3455771/21282566/a7452398-c3f6-11e6-99c9-0aa632a9efd6.png)


