### PR TITLE
Use formatted numbers returned from the API

### DIFF
--- a/src/app/components/job-list-item/job-list-item.component.html
+++ b/src/app/components/job-list-item/job-list-item.component.html
@@ -6,9 +6,9 @@
 
   <div class="row">
     <div class="col-xs-8">
-      <span class="total-salary">{{job.grossAmount}} {{job.hourlyPay.currency}}</span>
+      <span class="total-salary">{{job.grossAmountWithCurrency}}</span>
       <span class="salary-per-hour">
-        {{job.hours}}h ({{job.hourlyPay.grossSalary}} {{job.hourlyPay.currency}}/h)
+        {{job.hours}}h ({{job.hourlyPay.grossSalaryWithUnit}})
       </span>
     </div>
 

--- a/src/app/components/job-map-marker/job-map-marker.component.html
+++ b/src/app/components/job-map-marker/job-map-marker.component.html
@@ -2,7 +2,7 @@
   <sebm-google-map-info-window [disableAutoPan]="true" [isOpen]="job.showJobInfo" (infoWindowClose)="job.showJobInfo = false">
     <p class="job-map-marker-info-header">{{job.name}}
     <p class="job-map-marker-info-adress-field"><i class="fa fa-map-marker" aria-hidden="true"></i> {{job.address}}</p>
-    <span class="job-map-marker-info-salary">{{job.grossAmount}} {{job.hourlyPay.currency}}</span>
+    <span class="job-map-marker-info-salary">{{job.grossAmountWithCurrency}}</span>
     <span class="job-map-marker-info-salary-per-hour">{{job.hours}}h ({{job.hourlyPay.grossSalary}} {{job.hourlyPay.currency}}/h)</span>
     <div class="btn-secondary btn-xsmall btn job-map-marker-info-button" (click)="goToJob()">Go to job</div>
   </sebm-google-map-info-window>

--- a/src/app/components/slider/slider.component.html
+++ b/src/app/components/slider/slider.component.html
@@ -4,7 +4,7 @@
         <div class="job-name"><div>
           {{job.name}}
         </div></div>
-        <div class="salary-container">{{job.hourlyPay.grossSalary * job.hours}} {{job.hourlyPay.currency}}</div>
+        <div class="salary-container">{{job.grossAmountWithCurrency}}</div>
       </div>
   </div>
 </div>

--- a/src/app/models/job/job.ts
+++ b/src/app/models/job/job.ts
@@ -17,7 +17,11 @@ export class Job {
   id: string;
   invoiceAmount: number;
   grossAmount: number;
+  grossAmountDelimited: string;
+  grossAmountWithCurrency: string;
   netAmount: number;
+  netAmountDelimited: string;
+  netAmountWithCurrency: string;
   jobDate: string;
   jobEndDate: string;
   name: string;
@@ -40,6 +44,10 @@ export class Job {
     }
 
     this.grossAmount = jsonObject.gross_amount;
+    this.grossAmountDelimited = jsonObject.gross_amount_delimited;
+    this.grossAmountWithCurrency = jsonObject.gross_amount_with_currency;
+    this.netAmountDelimited = jsonObject.net_amount_delimited;
+    this.netAmountWithCurrency = jsonObject.net_amount_with_currency;
     this.netAmount = jsonObject.net_amount;
     this.company = new Company(jsonObject.company);
     this.createdAt = jsonObject.created_at;
@@ -115,9 +123,14 @@ export class Job {
 export class HourlyPay {
   active: boolean;
   currency: string;
+  unit: string;
   grossSalary: number;
+  grossSalaryDelmited: string;
+  grossSalaryWithUnit: string;
   id: string;
   netSalary: number;
+  netSalaryDelmited: string;
+  netSalaryWithUnit: string;
   rateIncludingVAT: number;
 
   constructor(jsonObject: any) {
@@ -126,9 +139,14 @@ export class HourlyPay {
     }
     this.active = jsonObject.active;
     this.currency = jsonObject.currency;
+    this.unit = jsonObject.unit;
     this.grossSalary = jsonObject.gross_salary;
+    this.grossSalaryDelmited = jsonObject.gross_salary_delmited;
+    this.grossSalaryWithUnit = jsonObject.gross_salary_with_unit;
     this.id = jsonObject.id;
     this.netSalary = jsonObject.net_salary;
+    this.netSalaryDelmited = jsonObject.net_salary_delmited;
+    this.netSalaryWithUnit = jsonObject.net_salary_with_unit;
     this.rateIncludingVAT = jsonObject.rate_including_vat;
   }
 }

--- a/src/app/views/home/home.component.html
+++ b/src/app/views/home/home.component.html
@@ -45,7 +45,7 @@
           </div>
         </div>
         <div class="home-job-item-salary-container">
-          {{job.hourlyPay.grossSalary * job.hours}} {{job.hourlyPay.currency}}
+          {{job.grossAmountWithCurrency }}
         </div>
       </div>
     </div>

--- a/src/app/views/job-details/job-details.component.html
+++ b/src/app/views/job-details/job-details.component.html
@@ -13,7 +13,7 @@
             <h4 class="job-status-text">{{job.company.name}}</h4>
             <h6 class="job-status-text">{{job.jobDate | date: 'MMM dd'}} - {{job.jobEndDate | date: 'MMM dd'}}</h6>
             <h6 class="job-status-text">{{job.street}}</h6>
-            <h2 class="job-status-salary-text">{{job.grossAmount}} {{job.currency}}</h2>
+            <h2 class="job-status-salary-text">{{job.grossAmountWithCurrency}}</h2>
           </div>
           <div class="col-xs-5 job-status-icon-container">
             <img [src]="job.companyLogoURL" class="company-logo">
@@ -68,8 +68,8 @@
       <div class="row job-preview-row">
         <div class="col-xs-1"></div>
         <div class="col-xs-11">
-          <p class="job-preview-text">{{job.hours}} {{'assignment.hours' | translate}} ({{job.hourlyPay.grossSalary}} {{job.hourlyPay.currency}}/{{'assignment.hour' | translate | lowercase}}) {{'assignment.rate.gross_salary' | translate}}<br/>
-          {{job.netAmount}} {{job.hourlyPay.currency}} {{'assignment.after_tax' | translate}}</p>
+          <p class="job-preview-text">{{job.hours}} {{'assignment.hours' | translate}} ({{job.hourlyPay.grossSalaryWithUnit}} {{'assignment.rate.gross_salary' | translate}})<br/>
+          {{job.netAmountWithCurrency}} {{'assignment.after_tax' | translate}}</p>
           <hr class="job-details-separator"/>
         </div>
       </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -3,7 +3,6 @@
   "assignment.after_tax": "after tax",
   "assignment.assignments.title": "Job",
   "assignment.details": "Job details",
-  "assignment.hour": "Hour",
   "assignment.hours": "Hours",
   "assignment.rate.gross_salary": "gross salary",
   "assignment.status.applied": "You have applied for this job",


### PR DESCRIPTION
Update `job-list-item`, `job-map-marker`, `slider`, `job-details` and `home` component to use formatted numbers returned from the API.

---

# Before

<img width="310" alt="screen shot 2017-02-21 at 20 36 44" src="https://cloud.githubusercontent.com/assets/922411/23181487/79f0e19e-f875-11e6-847e-5e0c3a07bc13.png">
<img width="354" alt="screen shot 2017-02-21 at 20 36 41" src="https://cloud.githubusercontent.com/assets/922411/23181490/79f3a19a-f875-11e6-9b69-1d19c393a1d3.png">
<img width="263" alt="screen shot 2017-02-21 at 20 36 32" src="https://cloud.githubusercontent.com/assets/922411/23181488/79f22752-f875-11e6-9814-71cd188ebdf1.png">
<img width="244" alt="screen shot 2017-02-21 at 20 36 18" src="https://cloud.githubusercontent.com/assets/922411/23181489/79f307b2-f875-11e6-9a6a-bb6e0fb7daa3.png">
<img width="202" alt="screen shot 2017-02-21 at 20 36 13" src="https://cloud.githubusercontent.com/assets/922411/23181491/79f52376-f875-11e6-8575-323189e1edfa.png">

# After

<img width="204" alt="new6" src="https://cloud.githubusercontent.com/assets/922411/23181503/7f03e5aa-f875-11e6-9fca-f0375fb0577b.png">
<img width="306" alt="new5" src="https://cloud.githubusercontent.com/assets/922411/23181500/7f01bd48-f875-11e6-9efa-532199ae0f36.png">
<img width="377" alt="new4" src="https://cloud.githubusercontent.com/assets/922411/23181502/7f01c27a-f875-11e6-93a2-b0816a4be050.png">
<img width="303" alt="new3" src="https://cloud.githubusercontent.com/assets/922411/23181499/7f01296e-f875-11e6-90ea-2a13b3a065df.png">
<img width="264" alt="new2" src="https://cloud.githubusercontent.com/assets/922411/23181501/7f01b352-f875-11e6-8f74-9734c0a355f7.png">
<img width="203" alt="new1" src="https://cloud.githubusercontent.com/assets/922411/23181504/7f177c0a-f875-11e6-8a72-373ad835b132.png">
