### PR TITLE
Nest preview_key param listener to be fetched _before_ the job is requested

### DIFF
--- a/src/app/components/pages/job-page/job-page.component.ts
+++ b/src/app/components/pages/job-page/job-page.component.ts
@@ -207,19 +207,15 @@ export class JobPageComponent extends PageComponent {
 
   public onInit(): void {
     this.initRouteParamsSubscription();
-    this.initQueryParamsSubscription();
   }
 
   private initRouteParamsSubscription(): void {
     this.routeParamsSubscription = this.route.params.subscribe(params => {
       this.jobId = params[JobPageComponent.idParam];
-      this.loadData();
-    });
-  }
-
-  private initQueryParamsSubscription(): void {
-    this.queryParamsSubscription = this.route.queryParams.subscribe(params => {
-      this.previewKey = params[JobPageComponent.previewKeyParam];
+      this.queryParamsSubscription = this.route.queryParams.subscribe(params => {
+        this.previewKey = params[JobPageComponent.previewKeyParam];
+        this.loadData();
+      });
     });
   }
 
@@ -229,8 +225,7 @@ export class JobPageComponent extends PageComponent {
 
   private loadData(): void {
     this.jobPromise = this.jobProxy.getJob(this.jobId, {
-      'include': JobPageComponent.includes
-    }, {
+      'include': JobPageComponent.includes,
       'preview_key': this.previewKey
     })
     .then(job => {


### PR DESCRIPTION
Quite an ugly solution, but should (?) work ;)

The problem was that the query-param listener was fetched __after__ the job was fetched. Causing the preview_key to always be nil when requesting the job.