### PR TITLE
Add basic-user-data-page.component

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,8 @@ import {BasicTabComponent} from './components/tabs/basic-tab/basic-tab.component
 import {BasicTabsComponent} from './components/tabs/basic-tabs/basic-tabs.component';
 import {BasicTextComponent} from './components/text/basic-text/basic-text.component';
 import {BasicTitleTextComponent} from './components/text/basic-title-text/basic-title-text.component';
+import {BasicUserDataFormComponent} from './components/forms/basic-user-data-form/basic-user-data-form.component';
+import {BasicUserDataPageComponent} from './components/pages/basic-user-data-page/basic-user-data-page.component';
 import {BrowserModule} from '@angular/platform-browser';
 import {ChatMessageInputComponent} from './components/inputs/chat-message-input/chat-message-input.component';
 import {CheckboxInputComponent} from './components/inputs/checkbox-input/checkbox-input.component';
@@ -317,6 +319,8 @@ export class RavenErrorHandler implements ErrorHandler {
     BasicTabsComponent,
     BasicTextComponent,
     BasicTitleTextComponent,
+    BasicUserDataFormComponent,
+    BasicUserDataPageComponent,
     ChatMessageInputComponent,
     CheckboxInputComponent,
     CircularIconBaseButtonComponent,

--- a/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.html
+++ b/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.html
@@ -1,0 +1,66 @@
+<form
+  (keydown.enter)="$event.preventDefault()"
+  (ngSubmit)="submitForm()"
+  #form="ngForm"
+  class="ui form">
+
+  <basic-loader
+    [complete]="!loadingSubmit"
+    class="inverted">
+  </basic-loader>
+
+  <form-section-title-text
+    [text]="'user.profile.form.work.experience.section.header' | translate"
+    icon="suitcase">
+  </form-section-title-text>
+
+  <resume-input
+    [centered]="true"
+    [showLabel]="false">
+  </resume-input>
+
+  <form-section-title-text
+    [text]="'user.settings.form.personal.info.header' | translate"
+    icon="user">
+  </form-section-title-text>
+
+  <form-section-title-text
+    [text]="'user.profile.form.language.skills.section.header' | translate"
+    icon="world">
+  </form-section-title-text>
+
+  <languages-input
+    [languagesControl]="settingsForm.controls['languages']"
+    [userLanguagesControl]="settingsForm.controls['user_languages']"
+    [apiErrors]="apiErrors">
+  </languages-input>
+
+  <form-section-title-text
+    [text]="'user.profile.form.general.skills.section.header' | translate"
+    icon="rocket">
+  </form-section-title-text>
+
+  <skills-input
+    [skillsControl]="settingsForm.controls['skills']"
+    [userSkillsControl]="settingsForm.controls['user_skills']"
+    [apiErrors]="apiErrors">
+  </skills-input>
+
+  <form-section-title-text
+    [text]="'user.profile.form.interests.section.header' | translate"
+    icon="heart">
+  </form-section-title-text>
+
+  <interests-input
+    [interestsControl]="settingsForm.controls['interests']"
+    [userInterestsControl]="settingsForm.controls['user_interests']"
+    [apiErrors]="apiErrors">
+  </interests-input>
+
+  <form-submit-button
+    [buttonText]="'user.settings.form.submit.button' | translate"
+    [showButton]="!isInModal"
+    [submitFail]="submitFail"
+    [submitSuccess]="submitSuccess">
+  </form-submit-button>
+</form>

--- a/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.html
+++ b/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.html
@@ -20,11 +20,6 @@
   </resume-input>
 
   <form-section-title-text
-    [text]="'user.settings.form.personal.info.header' | translate"
-    icon="user">
-  </form-section-title-text>
-
-  <form-section-title-text
     [text]="'user.profile.form.language.skills.section.header' | translate"
     icon="world">
   </form-section-title-text>

--- a/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.ts
+++ b/src/app/components/forms/basic-user-data-form/basic-user-data-form.component.ts
@@ -1,0 +1,112 @@
+import {ApiErrors} from '../../../models/api-models/api-errors/api-errors';
+import {ChangeDetectorRef} from '@angular/core';
+import {Component} from '@angular/core';
+import {FormBuilder} from '@angular/forms';
+import {FormGroup} from '@angular/forms';
+import {Input} from '@angular/core';
+import {map} from 'lodash';
+import {NavigationService} from '../../../services/navigation.service';
+import {User} from '../../../models/api-models/user/user';
+import {UserPasswordProxy} from '../../../proxies/user-password/user-password.proxy';
+import {UserProxy} from '../../../proxies/user/user.proxy';
+import {UserResolver} from '../../../resolvers/user/user.resolver';
+import {Validators} from '@angular/forms';
+import {BaseComponent} from '../../base.component';
+import {SystemLanguagesResolver} from '../../../resolvers/system-languages/system-languages.resolver';
+
+@Component({
+  selector: 'basic-user-data-form',
+  templateUrl: './basic-user-data-form.component.html'
+})
+export class BasicUserDataFormComponent extends BaseComponent {
+  @Input() public isInModal: boolean = false;
+
+  public apiErrors: ApiErrors = new ApiErrors([]);
+  public loadingSubmit: boolean;
+  public settingsForm: FormGroup;
+  public submitFail: boolean;
+  public submitSuccess: boolean;
+
+  public constructor(
+    private changeDetector: ChangeDetectorRef,
+    private formBuilder: FormBuilder,
+    private navigationService: NavigationService,
+    private userPasswordProxy: UserPasswordProxy,
+    private userProxy: UserProxy,
+    protected systemLanguagesResolver: SystemLanguagesResolver,
+    protected userResolver: UserResolver,
+  ) {
+    super(systemLanguagesResolver, userResolver);
+  }
+
+  public onInit(): void {
+    this.initForm();
+  }
+
+  public userChanged(user: User): void {
+    this.initForm();
+  }
+
+  private initForm(): void {
+    if (this.user) {
+      this.settingsForm = this.formBuilder.group({
+        'interests': [''],
+        'languages': [''],
+        'skills': [''],
+        'user_interests': [this.user.userInterests.slice()],
+        'user_languages': [this.user.userLanguages.slice()],
+        'user_skills': [this.user.userSkills.slice()],
+      });
+    }
+  }
+
+  private handleServerErrors(errors): void {
+    this.submitFail = true;
+    this.apiErrors = errors;
+    this.loadingSubmit = false;
+    this.changeDetector.detectChanges();
+  }
+
+  public submitForm(): Promise<User> {
+    this.submitSuccess = false;
+    this.submitFail = false;
+    this.loadingSubmit = true;
+    this.apiErrors = new ApiErrors([]);
+
+    return this.userProxy.updateUser(this.user.id, {
+      'interest_ids': map(this.settingsForm.value.user_interests, userInterest => {
+        return {
+          id: userInterest['interest'].id,
+          level: userInterest['level']
+        };
+      }),
+      'language_ids': map(this.settingsForm.value.user_languages, userLanguage => {
+        return {
+          id: userLanguage['language'].id,
+          proficiency: userLanguage['proficiency']
+        };
+      }),
+      'skill_ids': map(this.settingsForm.value.user_skills, userSkill => {
+        return {
+          id: userSkill['skill'].id,
+          proficiency: userSkill['proficiency']
+        };
+      }),
+    }, {
+      'include': UserResolver.includes,
+    })
+    .then(user => {
+      this.userResolver.setUser(user);
+      this.submitSuccess = true;
+      this.loadingSubmit = false;
+      return user;
+    })
+    .catch(errors => {
+      this.handleServerErrors(errors);
+      if (this.isInModal) {
+        throw errors;
+      }
+      return null;
+    });
+  }
+}

--- a/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
+++ b/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
@@ -1,0 +1,70 @@
+import {Component} from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
+import {Inject} from '@angular/core';
+import {Meta} from '@angular/platform-browser';
+import {PageOptionsService} from '../../../services/page-options.service';
+import {PageComponent} from '../page.component';
+import {REQUEST} from '../../../../express-engine';
+import {SystemLanguagesResolver} from '../../../resolvers/system-languages/system-languages.resolver';
+import {TranslateService} from '@ngx-translate/core';
+import {UserResolver} from '../../../resolvers/user/user.resolver';
+
+@Component({
+  selector: 'basic-user-data-page',
+  template: `
+    <basic-tabs>
+      <basic-tab [tabTitle]="'Basic'">
+        <div class="ui centered grid">
+          <div class="fourteen wide mobile ten wide tablet eight wide computer column">
+            <basic-user-data-form></basic-user-data-form>
+          </div>
+        </div>
+      </basic-tab>
+      <basic-tab [tabTitle]="'user.profile.tab.profile.details.title' | translate">
+        <div class="ui centered grid">
+          <div class="fourteen wide mobile ten wide tablet eight wide computer column">
+            <user-profile-form></user-profile-form>
+          </div>
+        </div>
+      </basic-tab>
+      <basic-tab [tabTitle]="'user.profile.tab.personal.details.title' | translate">
+        <div class="ui centered grid">
+          <div class="fourteen wide mobile ten wide tablet eight wide computer column">
+            <basic-user-data-form></basic-user-data-form>
+          </div>
+        </div>
+      </basic-tab>
+    </basic-tabs>`
+})
+export class BasicUserDataPageComponent extends PageComponent {
+
+  public constructor (
+    @Inject(DOCUMENT) protected document: any,
+    @Inject(REQUEST) protected request: any,
+    protected meta: Meta,
+    protected pageOptionsService: PageOptionsService,
+    protected systemLanguagesResolver: SystemLanguagesResolver,
+    protected translateService: TranslateService,
+    protected userResolver: UserResolver,
+  ) {
+    super(
+      {
+        title: {
+          translate: true,
+          content: 'meta.user.profile.title'
+        },
+        description: {
+          translate: true,
+          content: 'meta.user.profile.description'
+        }
+      },
+      document,
+      meta,
+      pageOptionsService,
+      request,
+      systemLanguagesResolver,
+      translateService,
+      userResolver
+    );
+  }
+}

--- a/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
+++ b/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
@@ -30,7 +30,7 @@ import {UserResolver} from '../../../resolvers/user/user.resolver';
       <basic-tab [tabTitle]="'user.profile.tab.personal.details.title' | translate">
         <div class="ui centered grid">
           <div class="fourteen wide mobile ten wide tablet eight wide computer column">
-            <basic-user-data-form></basic-user-data-form>
+            <user-details-form></user-details-form>
           </div>
         </div>
       </basic-tab>

--- a/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
+++ b/src/app/components/pages/basic-user-data-page/basic-user-data-page.component.ts
@@ -13,7 +13,7 @@ import {UserResolver} from '../../../resolvers/user/user.resolver';
   selector: 'basic-user-data-page',
   template: `
     <basic-tabs>
-      <basic-tab [tabTitle]="'Basic'">
+      <basic-tab [tabTitle]="'basic_user.data.tab_title' | translate">
         <div class="ui centered grid">
           <div class="fourteen wide mobile ten wide tablet eight wide computer column">
             <basic-user-data-form></basic-user-data-form>

--- a/src/app/routes/ja-routes/ja-routes.ts
+++ b/src/app/routes/ja-routes/ja-routes.ts
@@ -21,5 +21,5 @@ export class JARoutes {
   public static subscriptions: JARoute = { url: () => '/subscriptions' };
   public static supportChat: JARoute = { url: () => '/support-chat'};
   public static user: JARoute = { url: () => '/user'};
-  public static basicUserData: JARoute = { url: () => '/basic-user-data'};
+  public static basicUserData: JARoute = { url: () => '/update-profile'};
 }

--- a/src/app/routes/ja-routes/ja-routes.ts
+++ b/src/app/routes/ja-routes/ja-routes.ts
@@ -21,4 +21,5 @@ export class JARoutes {
   public static subscriptions: JARoute = { url: () => '/subscriptions' };
   public static supportChat: JARoute = { url: () => '/support-chat'};
   public static user: JARoute = { url: () => '/user'};
+  public static basicUserData: JARoute = { url: () => '/basic-user-data'};
 }

--- a/src/app/routes/routes.module.ts
+++ b/src/app/routes/routes.module.ts
@@ -59,7 +59,7 @@ const routes: Routes = [
     { path: 'subscriptions', component: SubscriptionsPageComponent },
     { path: 'subscriptions/:subscriberUuid', component: SubscriptionsPageComponent },
     { path: 'user', component: UserProfilePageComponent, canActivate: [LoggedInGuard] },
-    { path: 'basic-user-data', component: BasicUserDataPageComponent, canActivate: [LoggedInGuard] },
+    { path: 'update-profile', component: BasicUserDataPageComponent, canActivate: [LoggedInGuard] },
     { path: '**', component: NotFoundPageComponent },
   ]}
 ];

--- a/src/app/routes/routes.module.ts
+++ b/src/app/routes/routes.module.ts
@@ -1,4 +1,5 @@
 import {ApplicationsPageComponent} from '../components/pages/applications-page/applications-page.component';
+import {BasicUserDataPageComponent} from '../components/pages/basic-user-data-page/basic-user-data-page.component';
 import {ContactPageComponent} from '../components/pages/contact-page/contact-page.component';
 import {CookiesAboutPageComponent} from '../components/pages/cookies-about-page/cookies-about-page.component';
 import {DefaultLayoutComponent} from '../components/layouts/default-layout/default-layout.component';
@@ -58,6 +59,7 @@ const routes: Routes = [
     { path: 'subscriptions', component: SubscriptionsPageComponent },
     { path: 'subscriptions/:subscriberUuid', component: SubscriptionsPageComponent },
     { path: 'user', component: UserProfilePageComponent, canActivate: [LoggedInGuard] },
+    { path: 'basic-user-data', component: BasicUserDataPageComponent, canActivate: [LoggedInGuard] },
     { path: '**', component: NotFoundPageComponent },
   ]}
 ];

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -22,6 +22,7 @@
   "back.to.jobs.section.link": "Find more jobs",
   "basic.chat.messages.empty": "No messages yet",
   "basic.comments.empty": "No comments yet",
+  "basic_user.data.tab_title": "Basic",
   "button.form.submit.fail": "There are some errors, please review them above.",
   "button.form.submit.success": "Success!",
   "card.document.upload.empty.documents": "Empty",


### PR DESCRIPTION
Adds route  `/basic-user-data`.

⚠️ Prerequisite for https://github.com/justarrived/just_match_api/pull/1320.

## TODO

- [ ] Update `BasicUserDataPageComponent` meta title and description
- [ ] Remove redundant dep. injections from `BasicUserDataPageComponent` and `BasicUserDataFormComponent`
- [x] Chose what the actual route should be (`/basic-user-data` is not that pretty..)
  - Went with `/update-profile`

## Screenshot
![screencapture-localhost-4200-basic-user-data-1509232484715](https://user-images.githubusercontent.com/922411/32139371-970807e0-bc46-11e7-976a-25627117b45f.png)
