### PR TITLE
[draft] Track page load

### DIFF
--- a/src/app/components/pages/page.component.ts
+++ b/src/app/components/pages/page.component.ts
@@ -55,7 +55,20 @@ export abstract class PageComponent extends BaseComponent implements OnInit, OnD
 
     this.pageOptionsService.setTransparentNavbarWhenTopScrolled(this.transparentNavbarWhenTopScrolled);
 
+    this.sendAnalyticsEvent();
+
     super.ngOnInit();
+  }
+
+  protected sendAnalyticsEvent() {
+    const data = {
+      url: this.getUrl(),
+    };
+
+    // TODO: Send the event (must be async) to the API
+    console.log('********* I just rendered a page! *********')
+    console.log(data)
+    console.log('*******************************************')
   }
 
   protected updatePageMeta(pageMeta: PageMeta) {

--- a/src/app/components/pages/page.component.ts
+++ b/src/app/components/pages/page.component.ts
@@ -62,7 +62,7 @@ export abstract class PageComponent extends BaseComponent implements OnInit, OnD
 
   protected sendAnalyticsEvent() {
     const data = {
-      url: this.getUrl(),
+      url: PageComponent.getUrl(this.request),
     };
 
     // TODO: Send the event (must be async) to the API


### PR DESCRIPTION
⚠️ Not at all ready for merge!

I'd like to be able send each page view to the API, so we can track users path through the system (especially useful for checking how users behave before they apply for a job).

The API uses a plugin for backend events called [ahoy](https://github.com/ankane/ahoy) and there is a simple client side JavaScript implementation [ahoy.js](https://github.com/ankane/ahoy.js).
Perhaps the simplest would be to include `ahoy.js` and then fire most of the events manually, rather than relying on its default behaviour (which wont work, since we have a SPA).